### PR TITLE
Improve enum behaviour

### DIFF
--- a/src/argparcel/__init__.py
+++ b/src/argparcel/__init__.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
 import dataclasses
 import enum
 import types
 import typing
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Callable, Mapping, Sequence
 
     import _typeshed
 

--- a/tests/test_argparcel.py
+++ b/tests/test_argparcel.py
@@ -79,6 +79,16 @@ class Thingy(enum.Enum):
     b = enum.auto()
 
 
+class ThingyStr(enum.StrEnum):
+    a = enum.auto()
+    b = enum.auto()
+
+
+class ThingyInt(enum.IntEnum):
+    a = 1
+    b = 42
+
+
 @dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
 class MooEnum:
     x: Thingy = Thingy.a
@@ -86,15 +96,30 @@ class MooEnum:
     z: Thingy | None
 
 
-def test_enum() -> None:
-    with (
-        contextlib.redirect_stdout(io.StringIO()) as f,
-        contextlib.suppress(SystemExit),
-    ):
-        argparcel.parse(MooEnum, ["--help"])
-    help_text = f.getvalue()
-    assert (
-        """usage: pytest [-h] [--x {a,b}] --y {a,b} [--z {a,b}]
+@dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
+class MooStrEnum:
+    x: ThingyStr = ThingyStr.a
+    y: ThingyStr
+    z: ThingyStr | None
+
+
+@dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
+class MooIntEnum:
+    x: ThingyInt = ThingyInt.a
+    y: ThingyInt
+    z: ThingyInt | None
+
+
+def test_enum_help() -> None:
+    for type_ in (MooEnum, MooStrEnum, MooIntEnum):
+        with (
+            contextlib.redirect_stdout(io.StringIO()) as f,
+            contextlib.suppress(SystemExit),
+        ):
+            argparcel.parse(type_, ["--help"])
+        help_text = f.getvalue()
+        assert (
+            """usage: pytest [-h] [--x {a,b}] --y {a,b} [--z {a,b}]
 
 options:
   -h, --help  show this help message and exit
@@ -102,9 +127,11 @@ options:
   --y {a,b}
   --z {a,b}
 """
-        in help_text
-    )
+            in help_text
+        )
 
+
+def test_enum() -> None:
     assert argparcel.parse(MooEnum, ["--y", "a"]) == MooEnum(
         x=Thingy.a, y=Thingy.a, z=None
     )
@@ -116,4 +143,34 @@ options:
     )
     assert argparcel.parse(MooEnum, ["--y", "b", "--z", "b"]) == MooEnum(
         x=Thingy.a, y=Thingy.b, z=Thingy.b
+    )
+
+
+def test_str_enum() -> None:
+    assert argparcel.parse(MooStrEnum, ["--y", "a"]) == MooStrEnum(
+        x=ThingyStr.a, y=ThingyStr.a, z=None
+    )
+    assert argparcel.parse(MooStrEnum, ["--y", "b"]) == MooStrEnum(
+        x=ThingyStr.a, y=ThingyStr.b, z=None
+    )
+    assert argparcel.parse(MooStrEnum, ["--x", "b", "--y", "b"]) == MooStrEnum(
+        x=ThingyStr.b, y=ThingyStr.b, z=None
+    )
+    assert argparcel.parse(MooStrEnum, ["--y", "b", "--z", "b"]) == MooStrEnum(
+        x=ThingyStr.a, y=ThingyStr.b, z=ThingyStr.b
+    )
+
+
+def test_int_enum() -> None:
+    assert argparcel.parse(MooIntEnum, ["--y", "a"]) == MooIntEnum(
+        x=ThingyInt.a, y=ThingyInt.a, z=None
+    )
+    assert argparcel.parse(MooIntEnum, ["--y", "b"]) == MooIntEnum(
+        x=ThingyInt.a, y=ThingyInt.b, z=None
+    )
+    assert argparcel.parse(MooIntEnum, ["--x", "b", "--y", "b"]) == MooIntEnum(
+        x=ThingyInt.b, y=ThingyInt.b, z=None
+    )
+    assert argparcel.parse(MooIntEnum, ["--y", "b", "--z", "b"]) == MooIntEnum(
+        x=ThingyInt.a, y=ThingyInt.b, z=ThingyInt.b
     )

--- a/tests/test_argparcel.py
+++ b/tests/test_argparcel.py
@@ -94,14 +94,13 @@ def test_enum() -> None:
         argparcel.parse(MooEnum, ["--help"])
     help_text = f.getvalue()
     assert (
-        """usage: pytest [-h] [--x {Thingy.a,Thingy.b}] --y {Thingy.a,Thingy.b}
-              [--z {Thingy.a,Thingy.b}]
+        """usage: pytest [-h] [--x {a,b}] --y {a,b} [--z {a,b}]
 
 options:
-  -h, --help            show this help message and exit
-  --x {Thingy.a,Thingy.b}
-  --y {Thingy.a,Thingy.b}
-  --z {Thingy.a,Thingy.b}
+  -h, --help  show this help message and exit
+  --x {a,b}
+  --y {a,b}
+  --z {a,b}
 """
         in help_text
     )

--- a/tests/test_argparcel.py
+++ b/tests/test_argparcel.py
@@ -119,7 +119,7 @@ def test_enum_help() -> None:
             argparcel.parse(type_, ["--help"])
         help_text = f.getvalue()
         assert (
-            """usage: pytest [-h] [--x {a,b}] --y {a,b} [--z {a,b}]
+            """[-h] [--x {a,b}] --y {a,b} [--z {a,b}]
 
 options:
   -h, --help  show this help message and exit


### PR DESCRIPTION
Closes #2 

The approach is to make `argparse` just work with strings of field names, and then convert the results as we desired after we get it out.