### PR TITLE
Get help from field "docstring" via AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ class _Args:
     b: Bird = Bird.puffin
 
     # A `Path` can be automatically converted from a string. Here we also specify a
-    # 'help' message along with a default by using `argparcel.arg`
-    c: pathlib.Path | None = argparcel.arg(help="specify a path", default=None)  # noqa: RUF009
+    # 'help' message by using a 'docstring' for the field.
+    c: pathlib.Path | None = None
+    """An important path."""
 
 
 if __name__ == "__main__":
@@ -98,7 +99,7 @@ options:
   -h, --help         show this help message and exit
   --a {1,2,3}
   --b {puffin,lark}
-  --c C              specify a path
+  --c C              An important path.
 
 $ uv run examples/example_1.py --a 2
 _Args(a=2, b=<Bird.puffin: 1>, c=None)

--- a/examples/example_1.py
+++ b/examples/example_1.py
@@ -27,8 +27,9 @@ class _Args:
     b: Bird = Bird.puffin
 
     # A `Path` can be automatically converted from a string. Here we also specify a
-    # 'help' message along with a default by using `argparcel.arg`
-    c: pathlib.Path | None = argparcel.arg(help="specify a path", default=None)  # noqa: RUF009
+    # 'help' message by using a 'docstring' for the field.
+    c: pathlib.Path | None = None
+    """An important path."""
 
 
 if __name__ == "__main__":

--- a/src/argparcel/docstrings.py
+++ b/src/argparcel/docstrings.py
@@ -18,10 +18,10 @@ if typing.TYPE_CHECKING:
 
 
 def get_field_docstrings(cls: type[_typeshed.DataclassInstance]) -> dict[str, str]:
-    """Extracts 'docstrings' for all fields in a dataclass, if present.
+    """Extracts any 'field docstrings' present in `cls`.
 
-    If a 'docstring' is not found for a given field, it will not be included in the
-    output.
+    Returns a mapping from field name -> docstring, only for fields with which strings
+    can be associated.
     """
     # Obtaining the source code might fail with an exception; we let that propagate up
     # to the user.

--- a/src/argparcel/docstrings.py
+++ b/src/argparcel/docstrings.py
@@ -11,9 +11,13 @@ from __future__ import annotations
 
 import ast
 import inspect
+import typing
+
+if typing.TYPE_CHECKING:
+    import _typeshed
 
 
-def get_field_docstrings(cls: type) -> dict[str, str]:
+def get_field_docstrings(cls: type[_typeshed.DataclassInstance]) -> dict[str, str]:
     """Extracts 'docstrings' for all fields in a dataclass, if present.
 
     If a 'docstring' is not found for a given field, it will not be included in the

--- a/src/argparcel/docstrings.py
+++ b/src/argparcel/docstrings.py
@@ -1,0 +1,66 @@
+"""Utility to parse 'field docstrings' from a dataclass.
+
+Static-analysis tools like pyright will interpret strings that appear immediately after
+the definition of a field in a dataclass as documentation for that field, so this is an
+'expected' concept. However, it is _not_ a feature of the Python runtime.
+
+For that reason we resort to some dastardly AST inspection to extract the messages.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+
+def get_field_docstrings(cls: type) -> dict[str, str]:
+    """Extracts 'docstrings' for all fields in a dataclass, if present.
+
+    If a 'docstring' is not found for a given field, it will not be included in the
+    output.
+    """
+    # Obtaining the source code might fail with an exception; we let that propagate up
+    # to the user.
+    source = inspect.getsource(cls)
+    tree = ast.parse(source)
+
+    # Find the class definition node; if it doesn't exist something is fundamentally
+    # broken, so we are happy with an assert.
+    class_node = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == cls.__name__
+        ),
+        None,
+    )
+    assert class_node is not None
+
+    result: dict[str, str] = {}
+
+    # Walk through the class body to collect field docstrings
+    i = 0
+    while i < len(class_node.body):
+        node = class_node.body[i]
+
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            field_name = node.target.id
+            docstring: str | None = None
+
+            # Check if the next statement is a string literal
+            if i + 1 < len(class_node.body):
+                next_node = class_node.body[i + 1]
+                if (
+                    isinstance(next_node, ast.Expr)
+                    and isinstance(next_node.value, ast.Constant)
+                    and isinstance(next_node.value.value, str)
+                ):
+                    docstring = next_node.value.value
+                    i += 1  # Skip over the docstring node
+
+            if docstring is not None:
+                result[field_name] = docstring
+
+        i += 1
+
+    return result

--- a/src/argparcel/docstrings.py
+++ b/src/argparcel/docstrings.py
@@ -48,17 +48,12 @@ def get_field_docstrings(cls: type[_typeshed.DataclassInstance]) -> dict[str, st
     for node, next_node in itertools.pairwise(class_node.body):
         if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
             field_name = node.target.id
-            docstring: str | None = None
 
-            # Check if the next statement is a string literal
             if (
                 isinstance(next_node, ast.Expr)
                 and isinstance(next_node.value, ast.Constant)
                 and isinstance(next_node.value.value, str)
             ):
-                docstring = next_node.value.value
-
-            if docstring is not None:
-                result[field_name] = docstring
+                result[field_name] = next_node.value.value
 
     return result

--- a/tests/test_argparcel.py
+++ b/tests/test_argparcel.py
@@ -17,7 +17,9 @@ import argparcel
 class Moo:
     a: int | None = None
     b: float
-    choice: Literal[1, 2, 3] | None = argparcel.arg(help="choose wisely", default=None)
+    choice: Literal[1, 2, 3] | None = None
+    """choose wisely"""
+
     path: pathlib.Path | None = None
     c: bool = True
     description: str | None = None

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+
 from argparcel.docstrings import get_field_docstrings
 
 
@@ -17,9 +18,26 @@ class Example1:
     """Message d."""
 
 
+@dataclasses.dataclass
+class Example2:
+    a: int
+    # Line deliberately left blank
+    """Message a.
+
+    This continues over multiple lines.
+    """
+
+
 def test_get_field_docstrings() -> None:
     assert get_field_docstrings(Example1) == {
         "a": "Message a.",
         "b": "Message b.",
         "d": "Message d.",
+    }
+
+    assert get_field_docstrings(Example2) == {
+        "a": """Message a.
+
+    This continues over multiple lines.
+    """
     }

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import dataclasses
+from argparcel.docstrings import get_field_docstrings
+
+
+@dataclasses.dataclass
+class Example1:
+    a: int
+    """Message a."""
+
+    b: int
+    "Message b."
+
+    c: float
+    d: str | None = None
+    """Message d."""
+
+
+def test_get_field_docstrings() -> None:
+    assert get_field_docstrings(Example1) == {
+        "a": "Message a.",
+        "b": "Message b.",
+        "d": "Message d.",
+    }

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -20,6 +20,9 @@ class Example1:
 
 @dataclasses.dataclass
 class Example2:
+    """Class docstring."""
+
+    """No-op string."""
     a: int
     # Line deliberately left blank
     """Message a.


### PR DESCRIPTION
Inspect the AST to get field 'docstrings'.

Overall I think this makes the user experience significantly better. I'm happy that this is achievable fairly simply, without requiring any non-stdlib dependencies.
