### PR TITLE
parse indented dataclasses

### DIFF
--- a/src/argparcel/docstrings.py
+++ b/src/argparcel/docstrings.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import ast
 import inspect
 import itertools
+import textwrap
 import typing
 
 if typing.TYPE_CHECKING:
@@ -27,7 +28,7 @@ def get_field_docstrings(cls: type[_typeshed.DataclassInstance]) -> dict[str, st
     # Obtaining the source code might fail with an exception; we let that propagate up
     # to the user.
     source = inspect.getsource(cls)
-    tree = ast.parse(source)
+    tree = ast.parse(textwrap.dedent(source))
 
     # Find the class definition node; if it doesn't exist something is fundamentally
     # broken, so we are happy with an assert.

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -44,3 +44,24 @@ def test_get_field_docstrings() -> None:
     This continues over multiple lines.
     """
     }
+
+
+def test_get_field_docstrings_inline() -> None:
+    @dataclasses.dataclass
+    class Example3:
+        """Class docstring."""
+
+        """No-op string."""
+        a: int
+        # Line deliberately left blank
+        """Message a.
+
+        This continues over multiple lines.
+        """
+
+    assert get_field_docstrings(Example3) == {
+        "a": """Message a.
+
+    This continues over multiple lines.
+    """
+    }


### PR DESCRIPTION
Previously this would have raised an exception in `ast.parse`
