### PR TITLE
Support `list[thing]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Args(a=2, b=3.2, c=False, d='moo')
 We also support:
 - `Literal` and `Enum`s forcing specific choices
 - conversion to types whose `__init__` accepts a string, e.g. `pathlib.Path`
+- annotated lists, e.g. `list[int]` or `list[pathlib.Path]`
 - 'help' can be provided too
 
 ```python
@@ -86,6 +87,9 @@ class Args:
     c: pathlib.Path | None = None
     """An important path."""
 
+    # A list will introduce a flag that consumes zero or more elements.
+    d: list[float] | None = None
+
 
 if __name__ == "__main__":
     print(argparcel.parse(Args))
@@ -93,19 +97,24 @@ if __name__ == "__main__":
 
 ```console
 $ uv run examples/example_1.py --help
-usage: example_1.py [-h] --a {1,2,3} [--b {puffin,lark}] [--c C]
+usage: example_1.py [-h] --a {1,2,3} [--b {puffin,lark}] [--c C] [--d [D ...]]
 
 options:
   -h, --help         show this help message and exit
   --a {1,2,3}
   --b {puffin,lark}
   --c C              An important path.
+  --d [D ...]
+
 
 $ uv run examples/example_1.py --a 2
-Args(a=2, b=<Bird.puffin: 1>, c=None)
+Args(a=2, b=<Bird.puffin: 1>, c=None, d=None)
 
 $ uv run examples/example_1.py --a 2 --b lark --c /somewhere/to/go
-Args(a=2, b=<Bird.lark: 2>, c=PosixPath('/somewhere/to/go'))
+Args(a=2, b=<Bird.lark: 2>, c=PosixPath('/somewhere/to/go'), d=None)
+
+$ uv run examples/example_1.py --a 2 --b lark --d 1.0 2.0 3.0
+Args(a=2, b=<Bird.lark: 2>, c=None, d=[1.0, 2.0, 3.0])
 ```
 
 ## Pitfall: forward-references

--- a/examples/example_1.py
+++ b/examples/example_1.py
@@ -34,6 +34,9 @@ class Args:
     c: pathlib.Path | None = None
     """An important path."""
 
+    # A list will introduce a flag that consumes zero or more elements.
+    d: list[float] | None = None
+
 
 if __name__ == "__main__":
     print(argparcel.parse(Args))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = ["pyright==1.1.400", "pytest>=8.3.5", "ruff==0.11.8"]
 
 
 [tool.pytest.ini_options]
-addopts = "--tb=short --capture=no --strict-config"
+addopts = "--tb=short --strict-config"
 testpaths = ["tests"]
 
 

--- a/src/argparcel/__init__.py
+++ b/src/argparcel/__init__.py
@@ -175,6 +175,7 @@ def _add_argument_from_field(  # noqa: C901
             args = typing.get_args(base_type)
             if len(args) != 1:
                 msg = f"Malformed list: {base_type}"
+                raise ValueError(msg)
             (element_type,) = args
             # NOTE: providing a list-as-default here would be bad because mutable.
             #   This is currently prevented by dataclasses preventing assigning mutable

--- a/src/argparcel/__init__.py
+++ b/src/argparcel/__init__.py
@@ -176,9 +176,9 @@ def _add_argument_from_field(
             if len(args) != 1:
                 msg = f"Malformed list: {base_type}"
             (element_type,) = args
-            # FIXME: providing a list-as-default here would be very bad because mutable.
-            #   Prevent that. But also we should allow the case of
-            #   `list[int] | None = None`
+            # TODO: providing a list-as-default here would be bad because mutable.
+            #   This is currently prevented by dataclasses preventing assigning mutable
+            #   defaults, so for now we don't try to handle this specially.
             _add_argument(
                 parser,
                 name=arg_name,

--- a/src/argparcel/__init__.py
+++ b/src/argparcel/__init__.py
@@ -23,6 +23,7 @@ def _ensure_field_type(
     type
     | enum.EnumType
     | types.UnionType
+    | types.GenericAlias
     | typing._UnionGenericAlias  # pyright: ignore [reportAttributeAccessIssue]
     | typing._LiteralGenericAlias  # pyright: ignore [reportAttributeAccessIssue]
 ):
@@ -30,6 +31,7 @@ def _ensure_field_type(
         type,
         enum.EnumType,
         types.UnionType,
+        types.GenericAlias,
         typing._UnionGenericAlias,  # pyright: ignore [reportAttributeAccessIssue]  # noqa: SLF001
         typing._LiteralGenericAlias,  # pyright: ignore [reportAttributeAccessIssue]  # noqa: SLF001
     ):
@@ -55,6 +57,7 @@ def _add_argument(
     choices: Sequence | _Unspecified = _UNSPECIFIED,
     type_: object = _UNSPECIFIED,
     action: type[argparse.Action] | _Unspecified = _UNSPECIFIED,
+    nargs: int | typing.Literal["?", "+", "*"] | None | _Unspecified = _UNSPECIFIED,
 ) -> argparse.Action:
     # Build up common arguments for `parser.add_argument` into this dictionary. This is
     # the easiest way for us to avoid passing in arguments that should be unspecified.
@@ -67,6 +70,8 @@ def _add_argument(
         kwargs["type"] = type_
     if action is not _UNSPECIFIED:
         kwargs["action"] = action
+    if nargs is not _UNSPECIFIED:
+        kwargs["nargs"] = nargs
 
     return parser.add_argument(name, help=help_, required=required, **kwargs)
 
@@ -164,6 +169,30 @@ def _add_argument_from_field(
         )
         return _UNSPECIFIED
 
+    if isinstance(base_type, types.GenericAlias):
+        origin = typing.get_origin(base_type)
+        if origin is list:
+            args = typing.get_args(base_type)
+            if len(args) != 1:
+                msg = f"Malformed list: {base_type}"
+            (element_type,) = args
+            # FIXME: providing a list-as-default here would be very bad because mutable.
+            #   Prevent that. But also we should allow the case of
+            #   `list[int] | None = None`
+            _add_argument(
+                parser,
+                name=arg_name,
+                help_=help_,
+                required=required,
+                default=default,
+                type_=element_type,
+                nargs="*",
+            )
+            return _UNSPECIFIED
+
+        msg = f"Unsupported GenericAlias: {base_type}"
+        raise ValueError(msg)
+
     if isinstance(base_type, typing._LiteralGenericAlias):  # pyright: ignore [reportAttributeAccessIssue]  # noqa: SLF001
         # Represent literal arguments with choices.
         _add_argument_choices(
@@ -214,6 +243,11 @@ def _add_argument_from_field(
             return getattr(base_type, value)
 
         return _lookup_enum_element
+
+    # Catch types that are not supported properly, and are probably accidental omissions
+    if base_type is list:
+        msg = "`list` must be subscripted; please use e.g. 'list[int]'"
+        raise ValueError(msg)
 
     _add_argument(
         parser,

--- a/src/argparcel/__init__.py
+++ b/src/argparcel/__init__.py
@@ -117,7 +117,7 @@ def _add_argument_choices[T](
     )
 
 
-def _add_argument_from_field(
+def _add_argument_from_field(  # noqa: C901
     parser: argparse.ArgumentParser,
     field: dataclasses.Field,
     name_to_type: Mapping[str, object],

--- a/src/argparcel/__init__.py
+++ b/src/argparcel/__init__.py
@@ -176,7 +176,7 @@ def _add_argument_from_field(  # noqa: C901
             if len(args) != 1:
                 msg = f"Malformed list: {base_type}"
             (element_type,) = args
-            # TODO: providing a list-as-default here would be bad because mutable.
+            # NOTE: providing a list-as-default here would be bad because mutable.
             #   This is currently prevented by dataclasses preventing assigning mutable
             #   defaults, so for now we don't try to handle this specially.
             _add_argument(

--- a/tests/test_argparcel.py
+++ b/tests/test_argparcel.py
@@ -295,5 +295,16 @@ def test_list_int() -> None:
     assert _parse(_Moo, "--x 1 2").x == [1, 2]
     assert _parse(_Moo, "--x 1 2 --y").x == [1, 2]
 
-    # FIXME: add test for failure case
+    with pytest.raises(argparse.ArgumentError, match="invalid int value: 'three'"):
+        assert _parse(_Moo, "--x 1 2 three")
 
+
+def test_list_int_or_none() -> None:
+    @dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
+    class _Moo:
+        x: list[int] | None = None
+
+    assert _parse(_Moo, "").x is None
+    assert _parse(_Moo, "--x").x == []
+    assert _parse(_Moo, "--x 1").x == [1]
+    assert _parse(_Moo, "--x 1 2").x == [1, 2]

--- a/tests/test_argparcel.py
+++ b/tests/test_argparcel.py
@@ -318,3 +318,18 @@ def test_list_int_or_none() -> None:
     assert _parse(_Moo, "--x").x == []
     assert _parse(_Moo, "--x 1").x == [1]
     assert _parse(_Moo, "--x 1 2").x == [1, 2]
+
+
+def test_list_path() -> None:
+    @dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
+    class _Moo:
+        x: list[pathlib.Path]
+
+    assert _parse(_Moo, "--x").x == []
+    assert _parse(_Moo, "--x a").x == [pathlib.Path("a")]
+    assert _parse(_Moo, "--x a/b c").x == [pathlib.Path("a", "b"), pathlib.Path("c")]
+    assert _parse(_Moo, "--x a/b c /d/e/f").x == [
+        pathlib.Path("a", "b"),
+        pathlib.Path("c"),
+        pathlib.Path("/d", "e", "f"),
+    ]

--- a/tests/test_argparcel.py
+++ b/tests/test_argparcel.py
@@ -282,6 +282,13 @@ def test_list_str() -> None:
     assert _parse(_Moo, "--x 1").x == ["1"]
     assert _parse(_Moo, "--x 1 two").x == ["1", "two"]
     assert _parse(_Moo, "--x 1 two --y").x == ["1", "two"]
+    assert """[-h] --x [X ...] [--y | --no-y]
+
+options:
+  -h, --help   show this help message and exit
+  --x [X ...]
+  --y, --no-y
+""" in _get_help_text(_Moo)
 
 
 def test_list_int() -> None:
@@ -297,6 +304,9 @@ def test_list_int() -> None:
 
     with pytest.raises(argparse.ArgumentError, match="invalid int value: 'three'"):
         assert _parse(_Moo, "--x 1 2 three")
+
+    with pytest.raises(argparse.ArgumentError, match="invalid int value: '3.0'"):
+        assert _parse(_Moo, "--x 1 2 3.0")
 
 
 def test_list_int_or_none() -> None:


### PR DESCRIPTION
For now we support 'simple' types that can be constructed given a string. This covers `str`, `int`, `float` as well as some potentially common potential uses such as `pathlib.Path`.

We leave potential covering of other cases (e.g. enum, Literal) to future work, if there is demand.

We don't try to raise errors for 'unsupported' element types, because in theory we support any type which is convertible from a string.