### PR TITLE
support variable-length tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We also support:
 - `Literal` and `Enum`s forcing specific choices
 - conversion to types whose `__init__` accepts a string, e.g. `pathlib.Path`
 - annotated lists, e.g. `list[int]` or `list[pathlib.Path]`
-- annotated homogeneous tuples of known length, e.g. `tuple[int, int]` or `tuple[str, str, str]`
+- annotated homogeneous tuples, e.g. `tuple[int, int]` or `tuple[str, ...]`
 - 'help' can be provided too
 
 ```python

--- a/src/argparcel/__init__.py
+++ b/src/argparcel/__init__.py
@@ -361,13 +361,22 @@ def _add_argument_from_field(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 msg = f"Empty tuples not supported: {base_type}"
                 raise ValueError(msg)
 
-            unique_element_types = set(args)
-            if len(unique_element_types) > 1:
-                msg = f"Only homogeneous tuples currently supported, found: {base_type}"
-                raise NotImplementedError(msg)
+            if len(args) == 2 and isinstance(args[1], types.EllipsisType):
+                # Variable-length tuple.
+                element_type = args[0]
+                nargs = "*"
 
-            (element_type,) = unique_element_types
-            nargs = len(args)
+            else:
+                unique_element_types = set(args)
+                if len(unique_element_types) > 1:
+                    msg = (
+                        "Only homogeneous tuples currently supported, "
+                        f"found: {base_type}"
+                    )
+                    raise NotImplementedError(msg)
+
+                (element_type,) = unique_element_types
+                nargs = len(args)
 
             if isinstance(element_type, _LiteralGenericAlias):
                 return _tuplify(

--- a/tests/test_argparcel.py
+++ b/tests/test_argparcel.py
@@ -491,8 +491,20 @@ def test_tuple_intn() -> None:
     class _Moo:
         x: tuple[int, ...]
 
-    with pytest.raises(NotImplementedError, match="Only homogeneous tuples"):
-        _parse(_Moo, "--x")
+    assert _parse(_Moo, "--x").x == ()
+    assert _parse(_Moo, "--x 1").x == (1,)
+    assert _parse(_Moo, "--x 1 2").x == (1, 2)
+    assert _parse(_Moo, "--x 1 2 3").x == (1, 2, 3)
+
+    with pytest.raises(argparse.ArgumentError, match="invalid int value: 'c'"):
+        _parse(_Moo, "--x 1 2 c")
+
+    assert """[-h] --x [X ...]
+
+options:
+  -h, --help   show this help message and exit
+  --x [X ...]
+""" in _get_help_text(_Moo)
 
 
 def test_tuple_int_at_least_1() -> None:

--- a/tests/test_argparcel.py
+++ b/tests/test_argparcel.py
@@ -537,6 +537,19 @@ options:
 """ in _get_help_text(_Moo)
 
 
+def test_tuple_litn() -> None:
+    @dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
+    class _Moo:
+        x: tuple[Literal[1, 2], ...]
+
+    assert _parse(_Moo, "--x").x == ()
+    assert _parse(_Moo, "--x 1").x == (1,)
+    assert _parse(_Moo, "--x 1 2 2").x == (1, 2, 2)
+
+    with pytest.raises(argparse.ArgumentError, match="invalid choice: '3'"):
+        _parse(_Moo, "--x 1 2 3")
+
+
 def test_tuple_enum2() -> None:
     @dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
     class _Moo:


### PR DESCRIPTION
Support the case of e.g. `tuple[int, ...]`
